### PR TITLE
Change throttle algorithm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,10 @@ my %WriteMakefileArgs = (
     NAME         => 'CGI::Application::Plugin::Throttle',
     VERSION_FROM => 'lib/CGI/Application/Plugin/Throttle.pm',
 
+    PREREQ_PM => {
+        'Digest::SHA'         => 5.6,
+    }
+
     TEST_REQUIRES => {
         'File::Find'          => 0,
         'Test::CheckManifest' => 0.9,

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 suggests                "CGI::Application";
 suggests                "Redis";
 
+requires                "Digest::SHA" => '5.60'; # last update on sha512
 build_requires          "ExtUtils::MakeMaker" => '6.64';
 
 test_requires           "Test::More";

--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,7 @@ build_requires          "ExtUtils::MakeMaker" => '6.64';
 
 test_requires           "Test::More";
 
-author_requires         "File::Find;
+author_requires         "File::Find";
 author_requires         "Test::CheckManifest";
 author_requires         "Test::NoTabs";
 author_requires         "Test::Pod";

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -74,6 +74,7 @@ use warnings;
 
 our $VERSION = '0.6';
 
+use Digest::SHA qw/sha512_base64/;
 
 
 =head1 METHODS
@@ -422,6 +423,17 @@ sub configure
 }
 
 
+# returns a 'key'
+#
+# This routine will take the normal key and adds a 'timeslot' to it, so all keys
+# will now fall in the same group during the time interval of the 'period'
+# Since the key is becomming uglier, we just base64 encode the sha512 hash
+#
+sub _digest_key_in_timeslot
+{
+    my ($self, $key ) = @_;
+    sha512_base64( $key . q{#} . (time() / $self->{ 'period' }) )
+}
 
 =head1 AUTHOR
 


### PR DESCRIPTION
This change will use a 'period' based time-slot for keeping track of incoming requests.

The downside is that if the limit -1 would have been reached in the previous time-slot, the number of requests starts counting from zero in the next  time-slot, potentially reaching twice the limit in the same period.

The previous algorithm would refresh the expire time after every hit and therefore could accumulate incoming requests by just keeping incrementing the counter. This could result in the limits being exceeded, even though in the timeframe of 'period' only 1 request happened.

As a side effect of how the counting is done (the number of elements in a list, rather then incrementing) we can also reduce the number of Redis calls.