### PR TITLE
Use throttle_keys

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5,6 +5,9 @@ Makefile.PL
 README.md
 lib/CGI/Application/Plugin/Throttle.pm
 t/00-load.t
+t/11-get_redis_key.t
+t/12-get_rule.t
+t/90-simple-integration.t
 xt/manifest.t
 xt/pod.t
 xt/style-no-tabs.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -5,7 +5,9 @@ Makefile.PL
 README.md
 lib/CGI/Application/Plugin/Throttle.pm
 t/00-load.t
-t/11-get_redis_key.t
+t/11-get_keys-default.t
+t/11-get_keys-list.t
+t/11-get_keys-undef.t
 t/12-get_rule.t
 t/90-simple-integration.t
 xt/manifest.t

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -256,15 +256,17 @@ always be '2'.
 sub count
 {
     my ($self) = (@_);
+    
+    my $key = $self->_get_key();
+    my $rule = $self->_get_throttle_rule();
 
     my $visits = 0;
-    my $max    = $self->{ 'limit' };
+    my $max    = $rule->{ 'limit' };
 
     if ( $self->{ 'redis' } )
     {
-        my $key = $self->_get_redis_key();
-        $key = $self->_digest_key_in_timeslot($key);
-        $visits = $self->{ 'redis' }->llen($key);
+        my $digest_key = $self->_digest_key_in_timeslot($key, $rule->{period});
+        $visits = $self->{ 'redis' }->llen($digest_key);
     }
     return ( $visits, $max );
 }
@@ -420,8 +422,8 @@ sub configure
 #
 sub _digest_key_in_timeslot
 {
-    my ($self, $key ) = @_;
-    sha512_base64( $key . q{#} . int(time() / $self->{ 'period' }) )
+    my ($self, $key, $period ) = @_;
+    sha512_base64( $key . q{#} . int(time() / $period ) )
 }
 
 # returns the 'key' relating to the current user / session etc.

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -299,6 +299,11 @@ sub throttle_callback
     my $key = $self->_get_key();
 
     #
+    # Get throttle rule
+    #
+    my $rule = $self->_get_throttle_rule();
+    
+    #
     # Use a timeslot defined digest key instead
     #
     $key = $self->_digest_key_in_timeslot($key);
@@ -312,15 +317,15 @@ sub throttle_callback
     #
     #  If too many redirect.
     #
-    if ( ($cur) && ( $self->{ 'exceeded' } ) && ( $cur > $self->{ 'limit' } ) )
+    if ( ($cur) && ( $rule->{ 'exceeded' } ) && ( $cur > $rule->{ 'limit' } ) )
     {
 
         #
         #  Redirect to a different run-mode..
         #
-        if ( $self->{ 'exceeded' } )
+        if ( $rule->{ 'exceeded' } )
         {
-            $cgi_app->prerun_mode( $self->{ 'exceeded' } );
+            $cgi_app->prerun_mode( $rule->{ 'exceeded' } );
             return;
         }
     }
@@ -440,6 +445,20 @@ sub _digest_key_in_timeslot
 # returns the 'key' relating to the current user / session etc.
 #
 sub _get_key { $_[0]->_get_redis_key }
+
+# return a set of key/value pairs for a specific key
+#
+sub _get_throttle_rule
+{
+    my $self = shift;
+    
+    my $rule = {
+        limit    => $self->{ 'limit' },
+        period   => $self->{ 'period' },
+        exceeded => $self->{ 'exceeded' },
+    };
+    return $rule;
+}
 
 =head1 AUTHOR
 

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -296,7 +296,7 @@ sub throttle_callback
     #
     # The key relating to this user.
     #
-    my $key = $self->_get_redis_key();
+    my $key = $self->_get_key();
 
     #
     # Use a timeslot defined digest key instead
@@ -436,6 +436,10 @@ sub _digest_key_in_timeslot
     my ($self, $key ) = @_;
     sha512_base64( $key . q{#} . int(time() / $self->{ 'period' }) )
 }
+
+# returns the 'key' relating to the current user / session etc.
+#
+sub _get_key { $_[0]->_get_redis_key }
 
 =head1 AUTHOR
 

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -143,6 +143,11 @@ sub new
     #
     $self->{ 'exceeded' } = "slow_down";
 
+    #
+    #  Set the code reference for getting the throttle keys
+    #
+    $self->{ 'throttle_keys_callback' } = $supplied{ 'throttle_keys_callback' }
+    || \&_get_default_throttle_keys;
 
     bless( $self, $class );
     return $self;
@@ -161,7 +166,7 @@ sub throttle
 {
     my $cgi_app = shift;
     return $cgi_app->{ __throttle_obj } if $cgi_app->{ __throttle_obj };
-
+    
     #
     #  Setup the prefix of the Redis keys to default to the name of
     # the CGI::Application.
@@ -171,7 +176,11 @@ sub throttle
     # distinct prefixes.
     #
     my $throttle = $cgi_app->{ __throttle_obj } =
-      __PACKAGE__->new( prefix => ref $cgi_app );
+      __PACKAGE__->new(
+        prefix => ref($cgi_app),
+        throttle_keys_callback => $cgi_app->can('throttle_keys'),
+      )
+    ;
 
     return $throttle;
 }
@@ -257,7 +266,7 @@ sub count
 {
     my ($self) = (@_);
     
-    my $key = $self->_get_key();
+    my $keys = $self->_get_keys();
     my $rule = $self->_get_throttle_rule();
 
     my $visits = 0;
@@ -265,7 +274,7 @@ sub count
 
     if ( $self->{ 'redis' } )
     {
-        my $digest_key = $self->_digest_key_in_timeslot($key, $rule->{period});
+        my $digest_key = $self->_digest_key_in_timeslot($keys, $rule->{period});
         $visits = $self->{ 'redis' }->llen($digest_key);
     }
     return ( $visits, $max );
@@ -298,7 +307,7 @@ sub throttle_callback
     #
     # The key relating to this user.
     #
-    my $key = $self->_get_key();
+    my $keys = $self->_get_keys();
 
     #
     # Get throttle rule
@@ -308,7 +317,7 @@ sub throttle_callback
     #
     #  If too many redirect.
     #
-    if ( my $exceeded = $self->_is_exceeded($rule, $key) )
+    if ( my $exceeded = $self->_is_exceeded($rule, $keys) )
     {
         $cgi_app->prerun_mode( $exceeded );
         return;
@@ -413,6 +422,15 @@ sub configure
 
 }
 
+#
+# This is the original default list of values
+#
+sub _get_default_throttle_keys
+{
+  remote_user     => $ENV{ REMOTE_USER },
+  remote_addr     => $ENV{ REMOTE_ADDR },
+  http_user_agent => $ENV{ HTTP_USER_AGENT },
+}
 
 # returns a 'key'
 #
@@ -422,13 +440,39 @@ sub configure
 #
 sub _digest_key_in_timeslot
 {
-    my ($self, $key, $period ) = @_;
-    sha512_base64( $key . q{#} . int(time() / $period ) )
+    my ($self, $keys, $period ) = @_;
+    my @throttle_keys = @$keys;
+    
+    # we need to preserve order and can not use random order of a hash
+    my (@keys, @vals);
+    for ( my $i =0  ; $i < @throttle_keys; )
+    {
+      push @keys, $throttle_keys[$i++];
+      push @vals, $throttle_keys[$i++] || '* * *';
+    }
+    my $key_string = join q{:}, @vals;
+    
+    $key_string .= q{#} . int(time() / $period );
+
+    sha512_base64( $key_string )
 }
 
-# returns the 'key' relating to the current user / session etc.
+# returns the 'keys' relating to the current user / session etc.
 #
-sub _get_key { $_[0]->_get_redis_key }
+sub _get_keys
+{
+    my $self = shift;
+    my @throttle_keys = $self->{ throttle_keys_callback }->();
+
+    # return undef, as an explicit instruction to ignote throttling at all
+    return undef if scalar(@throttle_keys) == 1 && !defined($throttle_keys[0]);
+    
+    # prepend the list with the prefix if missing
+    unshift @throttle_keys, (prefix => $self->{ prefix } )
+      unless exists  {@throttle_keys}->{ prefix };
+    
+    return \@throttle_keys;
+}
 
 # return a set of key/value pairs for a specific key
 #
@@ -448,14 +492,14 @@ sub _get_throttle_rule
 #
 sub _is_exceeded
 {
-    my ($self, $rule, $key) = @_;
+    my ($self, $rule, $keys) = @_;
     
     my $redis = $self->{ 'redis' } or return;
 
     #
     # Use a timeslot defined digest key instead
     #
-    my $digest_key = $self->_digest_key_in_timeslot($key, $rule->{period});
+    my $digest_key = $self->_digest_key_in_timeslot($keys, $rule->{period});
 
     #
     #  Increase the count, and set the expiry.

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -494,6 +494,8 @@ sub _is_exceeded
 {
     my ($self, $rule, $keys) = @_;
     
+    return unless defined $keys;
+    
     my $redis = $self->{ 'redis' } or return;
 
     #

--- a/t/11-get_keys-default.t
+++ b/t/11-get_keys-default.t
@@ -1,0 +1,31 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use CGI::Application::Plugin::Throttle;
+
+$ENV{ REMOTE_ADDR } = '192.169.0.1';
+$ENV{ REMOTE_USER } = 'Test User';
+$ENV{ HTTP_USER_AGENT } = 'TAP';
+
+my $mock_cgi = bless {}, 'MyCGI';
+my $throttle = throttle($mock_cgi);
+$throttle->configure( prefix => 'Mocked CGI' ) ;
+
+my $keys = $throttle->_get_keys;
+
+is_deeply( $keys => [
+        prefix          => 'Mocked CGI',
+        remote_user     => 'Test User',
+        remote_addr     => '192.169.0.1',
+        http_user_agent => 'TAP'
+    ],
+    "Default key as string"
+);
+
+done_testing();
+
+package MyCGI;
+
+1;

--- a/t/11-get_keys-list.t
+++ b/t/11-get_keys-list.t
@@ -1,0 +1,32 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use CGI::Application::Plugin::Throttle;
+
+$ENV{ REMOTE_ADDR } = '192.169.0.1';
+$ENV{ REMOTE_USER } = 'Test User';
+$ENV{ HTTP_USER_AGENT } = 'TAP';
+
+my $mock_cgi = bless {}, 'MyCGI';
+my $throttle = throttle($mock_cgi);
+$throttle->configure( prefix => 'Mocked CGI' ) ;
+
+my $keys = $throttle->_get_keys;
+
+is_deeply( $keys => [
+        prefix          => 'Mocked CGI',
+        tenant_id       => '1234',
+    ],
+    "Prefixed key and custom key"
+);
+
+done_testing();
+
+package MyCGI;
+
+sub throttle_keys {
+    tenant_id => '1234',
+}
+1;

--- a/t/11-get_keys-undef.t
+++ b/t/11-get_keys-undef.t
@@ -9,13 +9,21 @@ $ENV{ REMOTE_ADDR } = '192.169.0.1';
 $ENV{ REMOTE_USER } = 'Test User';
 $ENV{ HTTP_USER_AGENT } = 'TAP';
 
-my $mock_cgi = {};
+my $mock_cgi = bless {}, 'MyCGI';
 my $throttle = throttle($mock_cgi);
 $throttle->configure( prefix => 'Mocked CGI' ) ;
 
-my $key = $throttle->_get_key;
+my $keys = $throttle->_get_keys;
 
-is( $key, "Mocked CGI:Test User:192.169.0.1:TAP", "Default key as string");
+is( $keys => undef,
+    "Only 'undef', we should not throttle"
+);
 
 done_testing();
 
+package MyCGI;
+
+sub throttle_keys {
+    return undef
+}
+1;

--- a/t/11-get_redis_key.t
+++ b/t/11-get_redis_key.t
@@ -1,0 +1,21 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use CGI::Application::Plugin::Throttle;
+
+$ENV{ REMOTE_ADDR } = '192.169.0.1';
+$ENV{ REMOTE_USER } = 'Test User';
+$ENV{ HTTP_USER_AGENT } = 'TAP';
+
+my $mock_cgi = {};
+my $throttle = throttle($mock_cgi);
+$throttle->configure( prefix => 'Mocked CGI' ) ;
+
+my $key = $throttle->_get_key;
+
+is( $key, "Mocked CGI:Test User:192.169.0.1:TAP", "Default key as string");
+
+done_testing();
+

--- a/t/12-get_rule.t
+++ b/t/12-get_rule.t
@@ -1,0 +1,22 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use CGI::Application::Plugin::Throttle;
+
+my $mock_cgi = {};
+my $throttle = throttle($mock_cgi);
+
+my $rule = $throttle->_get_throttle_rule();
+
+is_deeply( $rule => {
+        limit     => 100,
+        period    => 60,
+        exceeded  => "slow_down"
+    },
+    "Default rules"
+);
+
+done_testing();
+

--- a/t/12-get_rule.t
+++ b/t/12-get_rule.t
@@ -5,7 +5,7 @@ use warnings;
 
 use CGI::Application::Plugin::Throttle;
 
-my $mock_cgi = {};
+my $mock_cgi = bless {}, 'MyCGI';
 my $throttle = throttle($mock_cgi);
 
 my $rule = $throttle->_get_throttle_rule();
@@ -20,3 +20,7 @@ is_deeply( $rule => {
 
 done_testing();
 
+
+package MyCGI;
+
+1;


### PR DESCRIPTION
Based on the refactored callback, this MR will add the possibility to use your own set of keys, instead of the default REMOTE_ADDR / REMOTE_USER / HTTP_USER_AGENT.

Documentation will follow.

This is a first step to use different 'keys' so one can now do inside the CGI Application:

```
sub throttle_keys {
    my $self = shift;
    my $runmode_group = $self->runmode eq 'login' ? 'login' : 'others';
    return (
        remote_addr => $ENV{ REMOTE_ADDR },
        runmode_group => $runmode_group,
    )
};
```


Next up: selective throttle rules