### PR TITLE
Selective rules

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -9,6 +9,7 @@ t/11-get_keys-default.t
 t/11-get_keys-list.t
 t/11-get_keys-undef.t
 t/12-get_rule.t
+t/90-callback-integration.t
 t/90-simple-integration.t
 xt/manifest.t
 xt/pod.t

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -148,6 +148,11 @@ sub new
     #
     $self->{ 'throttle_keys_callback' } = $supplied{ 'throttle_keys_callback' }
     || \&_get_default_throttle_keys;
+    
+    #
+    #  Set the code reference for getting throttle specific rules
+    #
+    $self->{ 'throttle_spec_callback' } = $supplied{ 'throttle_spec_callback' };
 
     bless( $self, $class );
     return $self;
@@ -179,6 +184,7 @@ sub throttle
       __PACKAGE__->new(
         prefix => ref($cgi_app),
         throttle_keys_callback => $cgi_app->can('throttle_keys'),
+        throttle_spec_callback => $cgi_app->can('throttle_spec'),
       )
     ;
 
@@ -267,7 +273,7 @@ sub count
     my ($self) = (@_);
     
     my $keys = $self->_get_keys();
-    my $rule = $self->_get_throttle_rule();
+    my $rule = $self->_get_throttle_rule( $keys );
 
     my $visits = 0;
     my $max    = $rule->{ 'limit' };
@@ -312,7 +318,7 @@ sub throttle_callback
     #
     # Get throttle rule
     #
-    my $rule = $self->_get_throttle_rule();
+    my $rule = $self->_get_throttle_rule( $keys );
     
     #
     #  If too many redirect.
@@ -479,6 +485,22 @@ sub _get_keys
 sub _get_throttle_rule
 {
     my $self = shift;
+    my $keys = shift;
+
+    return unless defined $keys;
+
+    my $default_rule = $self->_get_default_throttle_rule();
+    my $special_rule = $self->_get_special_throttle_rule( $keys );
+    my $throttle_rule =  { %$default_rule, %$special_rule };
+
+    return $throttle_rule
+}
+
+# returns the default set of rules, set by $throttle->configure
+#
+sub _get_default_throttle_rule
+{
+    my $self = shift;
     
     my $rule = {
         limit    => $self->{ 'limit' },
@@ -486,6 +508,33 @@ sub _get_throttle_rule
         exceeded => $self->{ 'exceeded' },
     };
     return $rule;
+}
+
+# returns the first rule whre all the filters are matched against the keys
+#
+sub _get_special_throttle_rule
+{
+    my ( $self, $keys ) = @_;
+    return { } unless $self->{ throttle_spec_callback };
+    
+    my @spec = $self->{ throttle_spec_callback }->();
+    
+    # set initial rule to an empty set, or the last spec if there is an odd list
+    my $rule = scalar @spec %2 ? pop @spec : {};
+
+    while ( my($filter, $rule ) = splice @spec, 0 , 2 )
+    {
+        next unless $self->_match_all( $filter, $keys );
+        return $rule
+    }
+    
+    return $rule;
+}
+
+sub _match_all
+{
+    my ($self, $filter,$keys) = @_;
+    return undef
 }
 
 # returns the runmode if the this is true for the given rule and key

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -534,21 +534,37 @@ sub _get_special_throttle_rule
 sub _match_all
 {
     my ($self, $filter, $keys) = @_;
+    
+    my $lookup = { @$keys };
+    
     foreach ( keys %$filter )
-    # we match if
-    # - the filter key exists in the other list of keys
-    # - and both are equal, but `undef` is not equal to `''` (an empty string)
+    #
+    # In natural language, not in Perl, the below test does match:
+    #
+    #  "if both are the same"
+    #
+    # that is, under the precondition that both exists,
+    # that both defined strings are the same, or both are undefined
+    #
+    # normally,in string comparision, `undef` is compared as an empty string
+    #
+    # take a class in boolean algebra and learn about The Morgan etc
+    #
+    # we do not match if:
+    #
     {
-        return unless exists $keys->{$_};
-        return if
+        return unless exists $lookup->{$_};
+        
+        next if 
             ( defined $filter->{$_} && $filter->{$_} )
-            ne
-            ( defined $keys->{$_}   && $keys->{$_}   )
-            
-            or
-            ( defined $filter->{$_} )
-            or
-            ( defined $keys->{$_}   )
+            eq
+            ( defined $lookup->{$_} && $lookup->{$_} );
+        
+        return if
+            ( defined $filter->{$_}                  )
+            ||
+            ( defined $lookup->{$_}                  );
+        
     }
     return !undef
 }

--- a/lib/CGI/Application/Plugin/Throttle.pm
+++ b/lib/CGI/Application/Plugin/Throttle.pm
@@ -533,8 +533,24 @@ sub _get_special_throttle_rule
 
 sub _match_all
 {
-    my ($self, $filter,$keys) = @_;
-    return undef
+    my ($self, $filter, $keys) = @_;
+    foreach ( keys %$filter )
+    # we match if
+    # - the filter key exists in the other list of keys
+    # - and both are equal, but `undef` is not equal to `''` (an empty string)
+    {
+        return unless exists $keys->{$_};
+        return if
+            ( defined $filter->{$_} && $filter->{$_} )
+            ne
+            ( defined $keys->{$_}   && $keys->{$_}   )
+            
+            or
+            ( defined $filter->{$_} )
+            or
+            ( defined $keys->{$_}   )
+    }
+    return !undef
 }
 
 # returns the runmode if the this is true for the given rule and key

--- a/t/12-get_rule.t
+++ b/t/12-get_rule.t
@@ -8,7 +8,7 @@ use CGI::Application::Plugin::Throttle;
 my $mock_cgi = bless {}, 'MyCGI';
 my $throttle = throttle($mock_cgi);
 
-my $rule = $throttle->_get_throttle_rule();
+my $rule = $throttle->_get_throttle_rule( [] );
 
 is_deeply( $rule => {
         limit     => 100,

--- a/t/12-get_rule.t
+++ b/t/12-get_rule.t
@@ -8,15 +8,136 @@ use CGI::Application::Plugin::Throttle;
 my $mock_cgi = bless {}, 'MyCGI';
 my $throttle = throttle($mock_cgi);
 
-my $rule = $throttle->_get_throttle_rule( [] );
 
-is_deeply( $rule => {
-        limit     => 100,
-        period    => 60,
-        exceeded  => "slow_down"
-    },
-    "Default rules"
-);
+
+subtest "Original and Basic behaviour" => sub {
+    
+    is_deeply( $throttle->_get_throttle_rule( [] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "slow_down"
+        },
+        "Default rules"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ foo => 1 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "slow_down"
+        },
+        "There are no filters etc."
+    );
+    
+};
+
+
+
+subtest "List without default" => sub {
+    
+    local $throttle->{throttle_spec_callback} = sub {
+        { foo => 1 } =>
+        {
+            exceeded => 'foo one',
+        },
+        
+        { foo => 1, bar => 2 } =>
+        {
+            exceeded => 'foo one / bar two',
+        },
+        
+        { foo => 2, bar => 2 } =>
+        {
+            exceeded => 'foo two / bar two',
+        },
+        
+        { bar => 2 } =>
+        {
+            exceeded => 'bar two',
+        }
+    };
+
+    is_deeply( $throttle->_get_throttle_rule( [] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "slow_down"
+        },
+        "Default rules"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ foo => 1 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "foo one"
+        },
+        "Match 'foo one'"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ foo => 1, bar => 2 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "foo one"
+        },
+        "Match 'foo one', the first match"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ foo => 2, bar => 2 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "foo two / bar two"
+        },
+        "Match 'foo two / bar two'"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ bar => 2 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "bar two"
+        },
+        "Match 'bar two', 'foo' does not exist"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ foo => 3 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "slow_down"
+        },
+        "Default rules again"
+    );
+    
+};
+
+
+
+subtest "List with default" => sub {
+    
+    local $throttle->{throttle_spec_callback} = sub {
+        { foo => 1 } =>
+        {
+            exceeded => 'foo one',
+        },
+        
+        {
+            exceeded => 'fall through',
+        }
+    };
+
+    is_deeply( $throttle->_get_throttle_rule( [] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "fall through"
+        },
+        "Falls through, none of the specified filters match"
+    );
+    
+    is_deeply( $throttle->_get_throttle_rule( [ foo => 1 ] ) => {
+            limit     => 100,
+            period    => 60,
+            exceeded  => "foo one"
+        },
+        "Match 'foo one'"
+    );
+    
+};
 
 done_testing();
 

--- a/t/90-callback-integration.t
+++ b/t/90-callback-integration.t
@@ -1,0 +1,105 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use Test::Time time => 7; # so, only 3 seconds left in this time slot
+
+use Test::WWW::Mechanize::CGIApp;
+
+my $mech = Test::WWW::Mechanize::CGIApp->new;
+$mech->app('MyTest::CGI::Application');
+foreach (1..3)
+{
+    $mech->get( 'https://test.tst/test.cgi' );
+    my $content = $mech->content;
+    is( $content, 'SIMPLE TEST', "Time Slot 1: Simple Test");
+    sleep 1;
+}
+
+foreach (1..5)
+{
+    $mech->get( 'https://test.tst/test.cgi' );
+    my $content = $mech->content;
+    is( $content, 'SIMPLE TEST', "Time Slot 2: Simple Test");
+    sleep 1;
+}
+
+foreach (1..5)
+{
+    $mech->get( 'https://test.tst/test.cgi' );
+    my $content = $mech->content;
+    is( $content, 'THROTTLED MORE', "Time Slot 2: Throttled");
+    sleep 1;
+}
+
+foreach (1..2)
+{
+    $mech->get( 'https://test.tst/test.cgi' );
+    my $content = $mech->content;
+    is( $content, 'SIMPLE TEST', "Time Slot 3: Simple Test");
+    sleep 1;
+}
+
+
+done_testing();
+
+
+
+
+package MyTest::CGI::Application;
+
+use strict;
+use warnings;
+
+use base 'CGI::Application';
+use CGI::Application::Plugin::Throttle;
+
+use Test::Mock::Redis;
+
+
+sub setup
+{
+    my $self = shift;
+    $self->throttle->configure(
+        redis => Test::Mock::Redis->new(server => 'redis_tester' ),
+        # leava defaults
+    );
+
+    $self->run_modes(
+        start       => 'simple_test',
+        slow_down   => 'throttled',
+        slow_more   => 'throttled_more',
+    );
+
+}
+
+sub throttle_keys
+{
+    foo => 1
+}
+
+sub throttle_spec
+{
+    { foo => 1 } =>
+    {
+        limit    => 5,
+        period   => 10,
+        exceeded => 'slow_more',
+    },
+}
+
+sub simple_test
+{
+    'SIMPLE TEST'
+}
+
+sub throttled
+{
+    'THROTTLED'
+}
+
+sub throttled_more
+{
+    'THROTTLED MORE'
+}


### PR DESCRIPTION
Now that we can have all sorts off different parts to build up a redis key, we can now also have multiple 'throttle rules' in a specification, This would allow different setting for different run modes 

A good example will be interesting to set up.

```
sub throttle_spec {
    { remote_user => undef } =>
    {
        limit => 10_000,
        period => 300,
    }
    
    # fall through if no filters apply, override 'exceeded' only
    {
        exceeded => 'default_slow_run_mode'
    }
}
```

Documentation follows